### PR TITLE
fix: add focus to quick fix action menu

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -331,7 +331,7 @@ function schema({ colors, styles }) {
       "list.inactiveSelectionForeground": "${colors.offWhite}",
       "menu.background": "${colors.bg}",
       "menu.foreground": "${colors.offWhite}",
-      "menu.selectionBackground": "${colors.transparent}",
+      "menu.selectionBackground": "${colors.focus}",
       "menu.selectionForeground": "${colors.bluishGrayBrighter}",
       "menu.separatorBackground": "${colors.darkerGray}",
       "menubar.selectionBackground": "${colors.selection}",

--- a/themes/poimandres-color-theme-noitalics-storm.json
+++ b/themes/poimandres-color-theme-noitalics-storm.json
@@ -276,7 +276,7 @@
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#252b37",
       "menu.foreground": "#e4f0fb",
-      "menu.selectionBackground": "#00000000",
+      "menu.selectionBackground": "#404350",
       "menu.selectionForeground": "#7390AA",
       "menu.separatorBackground": "#868cad",
       "menubar.selectionBackground": "#818cc425",

--- a/themes/poimandres-color-theme-noitalics.json
+++ b/themes/poimandres-color-theme-noitalics.json
@@ -276,7 +276,7 @@
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#1b1e28",
       "menu.foreground": "#e4f0fb",
-      "menu.selectionBackground": "#00000000",
+      "menu.selectionBackground": "#303340",
       "menu.selectionForeground": "#7390AA",
       "menu.separatorBackground": "#767c9d",
       "menubar.selectionBackground": "#717cb425",

--- a/themes/poimandres-color-theme-storm.json
+++ b/themes/poimandres-color-theme-storm.json
@@ -276,7 +276,7 @@
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#252b37",
       "menu.foreground": "#e4f0fb",
-      "menu.selectionBackground": "#00000000",
+      "menu.selectionBackground": "#404350",
       "menu.selectionForeground": "#7390AA",
       "menu.separatorBackground": "#868cad",
       "menubar.selectionBackground": "#818cc425",

--- a/themes/poimandres-color-theme.json
+++ b/themes/poimandres-color-theme.json
@@ -276,7 +276,7 @@
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#1b1e28",
       "menu.foreground": "#e4f0fb",
-      "menu.selectionBackground": "#00000000",
+      "menu.selectionBackground": "#303340",
       "menu.selectionForeground": "#7390AA",
       "menu.separatorBackground": "#767c9d",
       "menubar.selectionBackground": "#717cb425",


### PR DESCRIPTION
# Description
Adds focus color to quick fix action menu in VSCode >1.71.0

Fixes: #12 

# Screenshots 

Current             |  Suggested
:-------------------------:|:-------------------------:
![Screenshot from 2022-09-14 13-50-07](https://user-images.githubusercontent.com/38523983/190155309-721bb67d-a109-4f1f-be5e-f78eecb1cc9b.png) | ![Screenshot from 2022-09-14 14-25-54](https://user-images.githubusercontent.com/38523983/190155447-41edf251-a089-4724-9893-1493ac3111bc.png)
