### PR TITLE
set inactiveSelectionBackground color like activeSelectionBackground

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -327,7 +327,7 @@ function schema({ colors, styles }) {
       "list.highlightForeground": "${colors.lowerMint}",
       "list.hoverBackground": "${colors.focus}80",
       "list.hoverForeground": "${colors.offWhite}",
-      "list.inactiveSelectionBackground": "${colors.transparent}",
+      "list.inactiveSelectionBackground": "${colors.focus}80",
       "list.inactiveSelectionForeground": "${colors.offWhite}",
       "menu.background": "${colors.bg}",
       "menu.foreground": "${colors.offWhite}",

--- a/themes/poimandres-color-theme-noitalics-storm.json
+++ b/themes/poimandres-color-theme-noitalics-storm.json
@@ -272,7 +272,7 @@
       "list.highlightForeground": "#5fb3a1",
       "list.hoverBackground": "#40435080",
       "list.hoverForeground": "#e4f0fb",
-      "list.inactiveSelectionBackground": "#00000000",
+      "list.inactiveSelectionBackground": "#40435080",
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#252b37",
       "menu.foreground": "#e4f0fb",

--- a/themes/poimandres-color-theme-noitalics.json
+++ b/themes/poimandres-color-theme-noitalics.json
@@ -272,7 +272,7 @@
       "list.highlightForeground": "#5fb3a1",
       "list.hoverBackground": "#30334080",
       "list.hoverForeground": "#e4f0fb",
-      "list.inactiveSelectionBackground": "#00000000",
+      "list.inactiveSelectionBackground": "#30334080",
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#1b1e28",
       "menu.foreground": "#e4f0fb",

--- a/themes/poimandres-color-theme-storm.json
+++ b/themes/poimandres-color-theme-storm.json
@@ -272,7 +272,7 @@
       "list.highlightForeground": "#5fb3a1",
       "list.hoverBackground": "#40435080",
       "list.hoverForeground": "#e4f0fb",
-      "list.inactiveSelectionBackground": "#00000000",
+      "list.inactiveSelectionBackground": "#40435080",
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#252b37",
       "menu.foreground": "#e4f0fb",

--- a/themes/poimandres-color-theme.json
+++ b/themes/poimandres-color-theme.json
@@ -272,7 +272,7 @@
       "list.highlightForeground": "#5fb3a1",
       "list.hoverBackground": "#30334080",
       "list.hoverForeground": "#e4f0fb",
-      "list.inactiveSelectionBackground": "#00000000",
+      "list.inactiveSelectionBackground": "#30334080",
       "list.inactiveSelectionForeground": "#e4f0fb",
       "menu.background": "#1b1e28",
       "menu.foreground": "#e4f0fb",


### PR DESCRIPTION
Thanks for your theme :)

Are you ok to give `list.inactiveSelectionBackground` same color as `list.activeSelectionBackground` ?

This is the background color set when this option is true : 

<img width="580" alt="CleanShot 2022-09-25 at 12 07 01@2x" src="https://user-images.githubusercontent.com/20722140/192138247-646c50f9-9811-4a3e-930d-094f0b55ba3c.png">

When you click on a Tab, the file tree scrolls to the matching file and highlight it.

Currently : 

![CleanShot 2022-09-25 at 12 12 39](https://user-images.githubusercontent.com/20722140/192138439-d40da185-0f7c-4f95-8a19-ea9bc6df0a39.gif)

With `list.inactiveSelectionBackground : "${colors.focus}80"` : 

![CleanShot 2022-09-25 at 12 14 23](https://user-images.githubusercontent.com/20722140/192138506-aed67572-5ba7-4b5f-911f-72299c583856.gif)

