### PR TITLE
add focus color for indentGuidesStroke

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -223,7 +223,7 @@ function schema({ colors, styles }) {
       "titleBar.activeForeground": "${colors.gray}",
       "titleBar.inactiveBackground": "${colors.bg}",
       "titleBar.inactiveForeground": "${colors.darkerGray}",
-      "tree.indentGuidesStroke": "${colors.transparent}",
+      "tree.indentGuidesStroke": "${colors.focus}",
       "widget.shadow": "${colors.black}30",
       "activityBar.activeBorder": "${colors.gray}",
       "activityBar.dropBorder": "${colors.gray}",

--- a/themes/poimandres-color-theme-noitalics-storm.json
+++ b/themes/poimandres-color-theme-noitalics-storm.json
@@ -168,7 +168,7 @@
       "titleBar.activeForeground": "#a6accd",
       "titleBar.inactiveBackground": "#252b37",
       "titleBar.inactiveForeground": "#868cad",
-      "tree.indentGuidesStroke": "#00000000",
+      "tree.indentGuidesStroke": "#404350",
       "widget.shadow": "#10101030",
       "activityBar.activeBorder": "#a6accd",
       "activityBar.dropBorder": "#a6accd",

--- a/themes/poimandres-color-theme-noitalics.json
+++ b/themes/poimandres-color-theme-noitalics.json
@@ -168,7 +168,7 @@
       "titleBar.activeForeground": "#a6accd",
       "titleBar.inactiveBackground": "#1b1e28",
       "titleBar.inactiveForeground": "#767c9d",
-      "tree.indentGuidesStroke": "#00000000",
+      "tree.indentGuidesStroke": "#303340",
       "widget.shadow": "#00000030",
       "activityBar.activeBorder": "#a6accd",
       "activityBar.dropBorder": "#a6accd",

--- a/themes/poimandres-color-theme-storm.json
+++ b/themes/poimandres-color-theme-storm.json
@@ -168,7 +168,7 @@
       "titleBar.activeForeground": "#a6accd",
       "titleBar.inactiveBackground": "#252b37",
       "titleBar.inactiveForeground": "#868cad",
-      "tree.indentGuidesStroke": "#00000000",
+      "tree.indentGuidesStroke": "#404350",
       "widget.shadow": "#10101030",
       "activityBar.activeBorder": "#a6accd",
       "activityBar.dropBorder": "#a6accd",

--- a/themes/poimandres-color-theme.json
+++ b/themes/poimandres-color-theme.json
@@ -168,7 +168,7 @@
       "titleBar.activeForeground": "#a6accd",
       "titleBar.inactiveBackground": "#1b1e28",
       "titleBar.inactiveForeground": "#767c9d",
-      "tree.indentGuidesStroke": "#00000000",
+      "tree.indentGuidesStroke": "#303340",
       "widget.shadow": "#00000030",
       "activityBar.activeBorder": "#a6accd",
       "activityBar.dropBorder": "#a6accd",


### PR DESCRIPTION
Hello again,

Same request for `tree.indentGuidesStroke` color 😬

Since we can disable this feature : 

<img width="457" alt="CleanShot 2022-09-25 at 12 21 06@2x" src="https://user-images.githubusercontent.com/20722140/192138725-7f1639a0-1b4c-44c5-883f-9a21542a0c9a.png">

Are you ok to give it the `focus` color?

It can really help to identify quickly what file is children of what folder.

Currently : 

![CleanShot 2022-09-25 at 12 25 05](https://user-images.githubusercontent.com/20722140/192138874-5cf5d8f7-e201-4dc7-8e69-a43ca1b7bbe9.gif)

With `"tree.indentGuidesStroke": "${colors.focus}"`

![CleanShot 2022-09-25 at 12 26 01](https://user-images.githubusercontent.com/20722140/192138922-7488144c-8890-4953-a911-30ec5c5a0ca2.gif)


