### PR TITLE
html text color problem fixed.

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -648,8 +648,6 @@ function schema({ colors, styles }) {
           "punctuation.definition.tag",
           "punctuation.separator.inheritance.php",
           "punctuation.definition.tag.html",
-          "punctuation.definition.tag.begin.html",
-          "punctuation.definition.tag.end.html",
           "punctuation.section.embedded",
           "keyword.other.template",
           "keyword.other.substitution",
@@ -657,6 +655,12 @@ function schema({ colors, styles }) {
         ],
         "settings": {
           "foreground": "${colors.offWhite}"
+        }
+      },
+      {
+        "scope": ["punctuation.definition.tag.begin.html", "punctuation.definition.tag.end.html"],
+        "settings": {
+          "foreground": "${colors.gray}"
         }
       },
       {
@@ -711,11 +715,16 @@ function schema({ colors, styles }) {
           "constant.other.key",
           "markup.heading",
           "markup.inserted.git_gutter",
-          "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js",
-          "text.html.derivative"
+          "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
         ],
         "settings": {
           "foreground": "${colors.brightMint}"
+        }
+      },
+      {
+        "scope": ["text.html.derivative"],
+        "settings": {
+          "foreground": "${colors.offWhite}"
         }
       },
       {


### PR DESCRIPTION
Hello,

In html, which I mentioned in the issue section, it was difficult to read because the text colors were the same color as the tags.

![Screen Shot 2022-11-06 at 21 58 33](https://user-images.githubusercontent.com/5020002/200190302-737407c5-e28b-45a1-82f6-e6e59be6dc46.png)

What has been done?

- The colors `"punctuation.definition.tag.begin.html"` and `"punctuation.definition.tag.end.html"` are set to gray.
- `"text.html.derivative"` color changed to `"offWhite".`

![Screen Shot 2022-11-06 at 21 59 36](https://user-images.githubusercontent.com/5020002/200190432-ecdecf1e-c97c-4069-bd83-be6d6217bb86.png)


issue: [https://github.com/drcmda/poimandres-theme/issues/17#issuecomment-1295925477](url)